### PR TITLE
Add company wise dsa page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "react-helmet": "^6.1.0",
         "react-icons": "^5.4.0",
         "react-router-dom": "^6.22.0",
-        "react-scripts": "5.0.1",
+        "react-scripts": "^5.0.1",
         "sitemap": "^8.0.0",
         "web-vitals": "^3.5.2"
       },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "react-helmet": "^6.1.0",
     "react-icons": "^5.4.0",
     "react-router-dom": "^6.22.0",
-    "react-scripts": "5.0.1",
+    "react-scripts": "^5.0.1",
     "sitemap": "^8.0.0",
     "web-vitals": "^3.5.2"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -72,7 +72,9 @@ function App() {
         <Route path="/ResumeBuilder" element={<ResumeBuilder />} />
         <Route path="/Resources" element={<Resources />} />
         <Route path="/Discussions" element={<Discussions />} />
-        <Route path="CompanyWiseDSA" element={<CompanyWiseDSA />} />
+
+        
+        <Route path="/resources/DSA-Companywiseimportant" element={<CompanyWiseDSA />} />
 
       </Routes>
     </BrowserRouter>

--- a/src/App.js
+++ b/src/App.js
@@ -11,7 +11,7 @@ import ProjectShowcase from './Page/ProjectShowcase.jsx';
 import ResumeBuilder from './Page/ResumeBuilder.jsx';
 import Resources from './Page/Resources.jsx';
 import Discussions from './Page/Discussions.jsx';
-
+import CompanyWiseDSA from './Page/DSA-Companywiseimportant.jsx';
 function App() {
   return (
     <BrowserRouter>
@@ -72,6 +72,8 @@ function App() {
         <Route path="/ResumeBuilder" element={<ResumeBuilder />} />
         <Route path="/Resources" element={<Resources />} />
         <Route path="/Discussions" element={<Discussions />} />
+        <Route path="CompanyWiseDSA" element={<CompanyWiseDSA />} />
+
       </Routes>
     </BrowserRouter>
   );

--- a/src/Page/DSA-Companywiseimportant.jsx
+++ b/src/Page/DSA-Companywiseimportant.jsx
@@ -1,0 +1,101 @@
+import React from "react";
+
+const CompanyWiseDSA = () => {
+  const companies = [
+    { name: "Google",  tricks: "Focus on backtracking and dynamic programming." },
+    { name: "Microsoft",  tricks: "Practice binary search, greedy algorithms." },
+    { name: "Amazon",  tricks: "Work on sliding window, heap, and DFS/BFS." },
+    // Add other companies here
+    
+    { name: "Nvidia",  tricks: "Practice bit manipulation and backtracking." },
+    { name: "FaceBook",  tricks: "Master recursion, graphs, and bit manipulation." },
+    { name: "Apple",  tricks: "Prioritize dynamic programming and divide and conquer." },
+    { name: "Adobe",  tricks: "Practice sorting and searching techniques." },
+    { name: "Goldman Sachs",  tricks: "Focus on arrays, hashing, and string manipulation." },
+    { name: "Uber",  tricks: "Work on graphs, BFS/DFS, and Dijkstra's algorithm." },
+    { name: "LinkedIn",  tricks: "Focus on two-pointer and sliding window techniques." },
+    { name: "Netflix",  tricks: "Prioritize dynamic programming and DP on trees." },
+    { name: "X(Twitter)",  tricks: "Work on greedy algorithms and interval problems." },
+    { name: "Dropbox",  tricks: "Master recursion and binary search on sorted arrays." },
+    { name: "Airbnb",  tricks: "Practice graph traversal and backtracking." },
+    { name: "Salesforce",  tricks: "Work on greedy algorithms and dynamic programming." },
+    { name: "Oracle",  tricks: "Focus on matrix traversal and dynamic programming." },
+    { name: "PayPal",  tricks: "Prioritize binary search and sorting problems." },
+    { name: "Walmart",  tricks: "Focus on hashing, prefix sums, and arrays." },
+    { name: "Expedia",  tricks: "Practice stack-based problems and recursion." },
+    { name: "Snap",  tricks: "Snap DSA Problems	Focus on graphs and dynamic programming." },
+    { name: "Yahoo",  tricks: "Work on linked lists and recursion." },
+    { name: "DoorDash",  tricks: "Master binary trees and backtracking" },
+    { name: "Stripe",  tricks: "Practice greedy algorithms and string manipulation." },
+    { name: "Lyft",  tricks: "Focus on two-pointer and sliding window techniques." },
+    { name: "Intuit",  tricks: "Work on backtracking and dynamic programming." },
+    { name: "IBM",  tricks: "Master dynamic programming and recursion problems." },
+    { name: "Atlassian",  tricks: "Focus on graph traversal and dynamic programming." },
+    { name: "Reddit",  tricks: "Work on hashing and bit manipulation." },
+    { name: "Pinterest",  tricks: "Master recursion and divide and conquer techniques." },
+    { name: "Spotify",  tricks: "Focus on sorting, searching, and heaps." },
+    { name: "Bloomberg",  tricks: "Work on arrays, dynamic programming, and graphs" },
+    { name: "Cisco",  tricks: "Focus on linked lists and dynamic programming." },
+    { name: "ByteDance",  tricks: "Master sorting algorithms and binary search." },
+    { name: "Tesla",  tricks: "Work on graph traversal and dynamic programming." },
+    { name: "TikTok",  tricks: "Prioritize dynamic programming and recursion." },
+    { name: "VMware",  tricks: "Focus on arrays and dynamic programming." },
+    { name: "Zillow",  tricks: "Work on binary search and sorting algorithms." },
+    { name: "Square",  tricks: "Master hashing and greedy algorithms." },
+    { name: "Quora",  tricks: "Focus on graphs and dynamic programming." },
+    { name: "Cisco",  tricks: "Work on arrays and dynamic programming." },
+    { name: "Dell",  tricks: "Master recursion and backtracking." },
+    { name: "HP",  tricks: "Focus on dynamic programming and greedy algorithms." },
+    { name: "Intel",  tricks: "Work on graphs and binary search." },
+    { name: "HCL",  tricks: "Practice arrays and string manipulation." },
+    { name: "Infosys",  tricks: "Focus on linked lists and dynamic programming." },
+    { name: "TCS",  tricks: "Master recursion and backtracking." },
+    { name: "Wipro",  tricks: "Work on dynamic programming and greedy algorithms." },
+    { name: "Accenture",  tricks: "Focus on graphs and binary search." },
+    { name: "Capgemini",  tricks: "Practice arrays and string manipulation." },
+    { name: "Cognizant",  tricks: "Master linked lists and dynamic programming." },
+    { name: "Tech Mahindra",  tricks: "Focus on recursion and backtracking." },
+    { name: "L&T Infotech",  tricks: "Work on dynamic programming and greedy algorithms." },
+    { name: "Mindtree",  tricks: "Focus on graphs and binary search." },
+    { name: "Persistent",  tricks: "Practice arrays and string manipulation." },
+    { name: "Mphasis",  tricks: "Master linked lists and dynamic programming." },
+    { name: "Hexaware",  tricks: "Focus on recursion and backtracking." },
+    { name: "Honeywell",  tricks: "Work on dynamic programming and greedy algorithms." },
+    { name: "LTI",  tricks: "Focus on graphs and binary search." },
+    { name: "Tata Elxsi",  tricks: "Practice arrays and string manipulation." },
+    { name: "Mindtree",  tricks: "Master linkedin" },
+   
+
+    
+  ];
+
+  return (
+    <div className="bg-gray-100 min-h-screen p-8">
+      <h1 className="text-2xl font-bold text-center mb-8">Company-wise DSA Problems</h1>
+      <table className="table-auto w-full border-collapse border border-gray-300">
+        <thead className="bg-gray-200">
+          <tr>
+            <th className="border border-gray-300 px-4 py-2">Company Name</th>
+            {/* <th className="border border-gray-300 px-4 py-2">DSA Problem Link</th> //can be added if needed  */}
+            <th className="border border-gray-300 px-4 py-2">Tricks for Solving Patterns</th>
+          </tr>
+        </thead>
+        <tbody>
+          {companies.map((company, index) => (
+            <tr key={index} className="hover:bg-gray-100">
+              <td className="border border-gray-300 px-4 py-2">{company.name}</td>
+              <td className="border border-gray-300 px-4 py-2">
+                <a href={company.link} className="text-blue-500 hover:underline">
+                  {company.name} DSA Problems
+                </a>
+              </td>
+              <td className="border border-gray-300 px-4 py-2">{company.tricks}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default CompanyWiseDSA;

--- a/src/Page/DSA-Companywiseimportant.jsx
+++ b/src/Page/DSA-Companywiseimportant.jsx
@@ -63,38 +63,33 @@ const CompanyWiseDSA = () => {
     { name: "Honeywell",  tricks: "Work on dynamic programming and greedy algorithms." },
     { name: "LTI",  tricks: "Focus on graphs and binary search." },
     { name: "Tata Elxsi",  tricks: "Practice arrays and string manipulation." },
-    { name: "Mindtree",  tricks: "Master linkedin" },
+    { name: "Mindtree",  tricks: "Master linked lists" },
    
 
     
   ];
 
   return (
-    <div className="bg-gray-100 min-h-screen p-8">
-      <h1 className="text-2xl font-bold text-center mb-8">Company-wise DSA Problems</h1>
-      <table className="table-auto w-full border-collapse border border-gray-300">
-        <thead className="bg-gray-200">
-          <tr>
-            <th className="border border-gray-300 px-4 py-2">Company Name</th>
-            {/* <th className="border border-gray-300 px-4 py-2">DSA Problem Link</th> //can be added if needed  */}
-            <th className="border border-gray-300 px-4 py-2">Tricks for Solving Patterns</th>
-          </tr>
-        </thead>
-        <tbody>
-          {companies.map((company, index) => (
-            <tr key={index} className="hover:bg-gray-100">
-              <td className="border border-gray-300 px-4 py-2">{company.name}</td>
-              <td className="border border-gray-300 px-4 py-2">
-                <a href={company.link} className="text-blue-500 hover:underline">
-                  {company.name} DSA Problems
-                </a>
-              </td>
-              <td className="border border-gray-300 px-4 py-2">{company.tricks}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
+<div className="bg-gray-100 min-h-screen p-8">
+  <h1 className="text-2xl font-bold text-center mb-8">Company-wise DSA Problems Topics </h1>
+  <table className="table-auto w-full border-collapse border border-gray-300">
+    <thead className="bg-gray-200">
+      <tr>
+        <th className="border border-gray-300 px-4 py-2">Company Name</th>
+        <th className="border border-gray-300 px-4 py-2">Tricks for Solving Patterns</th>
+      </tr>
+    </thead>
+    <tbody>
+      {companies.map((company, index) => (
+        <tr key={index} className="hover:bg-gray-100">
+          <td className="border border-gray-300 px-4 py-2">{company.name}</td>
+          <td className="border border-gray-300 px-4 py-2">{company.tricks}</td>
+        </tr>
+      ))}
+    </tbody>
+  </table>
+</div>
+
   );
 };
 

--- a/src/Page/Resources.jsx
+++ b/src/Page/Resources.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 
 const resources = [
   // Add resources here

--- a/src/Page/Resources.jsx
+++ b/src/Page/Resources.jsx
@@ -6,12 +6,26 @@ const resources = [
 
 const ResourcesPage = () => {
   return (
+    
     <div className="min-h-screen bg-gray-100 p-4">
       <header className="bg-blue-600 p-4 text-white">
         <h1 className="text-2xl font-bold">
           This is the Tech Resources Page - Want to Build this page as a contributer
         </h1>
       </header>
+
+        <div className="bg-gray-100 min-h-screen p-8">
+        <h1 className="text-2xl font-bold text-center mb-8">Resources</h1>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <Link
+            to="DSA-Companywiseimportant"
+            className="bg-blue-500 text-white rounded-lg p-6 flex items-center justify-center hover:bg-blue-600"
+          >
+            Company-wise DSA Problems
+          </Link>
+          {/* Add other resources here */}
+        </div>
+      </div> 
       <h1 className="text-2xl font-bold">Click here for features details 👇🏻</h1>
       <a href="https://github.com/codeaashu/DevDisplay/issues/600#issue-2758465270" target="_blank" rel="noreferrer">
         <button className="inline-flex cursor-pointer items-center rounded-lg border-2 border-textSecondary bg-textSecondary px-[15px] py-1.5 text-center font-poppoins text-sm transition-all duration-500 hover:bg-transparent hover:text-textSecondary dark:text-white">


### PR DESCRIPTION
 I have created and added the proposed DSA resources for various companies. The table now displays the Company Name and Tricks for Solving Patterns for each company to help users prepare for company-specific DSA problems.

Created and added a list of DSA resources for each company, including their respective tricks for solving patterns.
Updated the table to show only the Company Name and Tricks for Solving Patterns columns.


Kindly review this 
<img width="1470" alt="Screenshot 2025-01-01 at 11 37 59 AM" src="https://github.com/user-attachments/assets/176521c6-a63a-49e6-ab57-a34a3f2e9f61" />
<img width="1470" alt="Screenshot 2025-01-01 at 11 38 40 AM" src="https://github.com/user-attachments/assets/98e3fe72-88a3-4885-828f-7b9434fc644e" />

<br>
Kindly review this and let me know the suggestions @codeaashu 